### PR TITLE
Table revision

### DIFF
--- a/awk.sh
+++ b/awk.sh
@@ -3,9 +3,9 @@ extract_fastqc () {
     then
         echo "Supplies one or more fastqc result in zip file."
     fi
-    unset FileName BaseNameSignal OmitSignal OPTIND
+    unset FileName BaseNameSignal OmitSignal headersignal OPTIND
     FileName="FileName\t"
-    while getopts "bo" opt;
+    while getopts "boh" opt;
     do
         case $opt in
             #Print filename as in basename
@@ -15,6 +15,7 @@ extract_fastqc () {
             o) OmitSignal='1'
                FileName=""
                ;;
+            h) headersignal='1';;
         esac
     done
     shift "$(( OPTIND - 1 ))"
@@ -22,6 +23,11 @@ extract_fastqc () {
     echo -e "${FileName}TotalSeq\tLength\tGC\tAvgQScore (min,max)";
     for file in $@
     do
+        if [ -n $headersignal ]
+        then
+            echo -e '\t\t\t\t'
+        fi
+
         trimfile=${file##*/}
         unzip -p $file ${trimfile%.*}/fastqc_data.txt | \
         awk -F '\t'  -v omit=$OmitSignal -v base=$BaseNameSignal -v name=${trimfile%.*} \

--- a/awk.sh
+++ b/awk.sh
@@ -20,17 +20,18 @@ extract_fastqc () {
     done
     shift "$(( OPTIND - 1 ))"
 
-    echo -e "${FileName}TotalSeq\tLength\tGC\tAvgQScore (min,max)";
+    if [ -n "$headersignal" ]
+    then
+        echo -e "${FileName}TotalSeq\tLength\tGC\tAvgQScore (min,max)\tTotalSeq\tLength\tGC\tAvgQScore (min,max)";
+    else
+        echo -e "${FileName}TotalSeq\tLength\tGC\tAvgQScore (min,max)";
+    fi
+
     for file in $@
     do
-        if [ -n $headersignal ]
-        then
-            echo -e '\t\t\t\t'
-        fi
-
         trimfile=${file##*/}
         unzip -p $file ${trimfile%.*}/fastqc_data.txt | \
-        awk -F '\t'  -v omit=$OmitSignal -v base=$BaseNameSignal -v name=${trimfile%.*} \
+        awk -F '\t'  -v omit=$OmitSignal -v base=$BaseNameSignal -v name=${trimfile%.*} -v se=$headersignal \
         '/Filename/{if ( length(base)==0 ) {file=$2} else {gsub(/_[12]P*\..*/,"");file=$2}}
         /Total Sequences/{seq=$2}
         /Sequence length/{len=$2}
@@ -38,9 +39,11 @@ extract_fastqc () {
         /Per sequence quality scores/,/END/{nr[NR]=$1; n++ ;nrr[n]=$1 ; min=nrr[3]; max=nr[NR-1] ;$3=$1*$2; sumn+=$2;sum+=$3 ;}
     END{if (length(omit)==0){
         if ( sumn==0 ) {printf "%s\t%s\t%s\t%.3f\t%.3f (%s,%s)\n",file,0,0,0,0,0,0 ; exit};
+        if (length(se)!=0){printf "%s\t%s\t%s\t%.3f\t%.3f (%s,%s)\tNA\tNA\tNA\tNA\n",file,seq,len,gc,sum/sumn,min,max; exit};
         printf "%s\t%s\t%s\t%.3f\t%.3f (%s,%s)\n",file,seq,len,gc,sum/sumn,min,max
          }
     else {
+        if (length(se)!=0){printf "%s\t%s\t%.3f\t%.3f (%s,%s)\tNA\tNA\tNA\tNA\n",seq,len,gc,sum/sumn,min,max; exit};
         if ( sumn==0 ) {printf "%s\t%s\t%.3f\t%.3f (%s,%s)\n",0,0,0,0,0,0 ; exit};
         printf "%s\t%s\t%.3f\t%.3f (%s,%s)\n",seq,len,gc,sum/sumn,min,max
          }}' OFS='\t'

--- a/awk.sh
+++ b/awk.sh
@@ -18,12 +18,6 @@ extract_fastqc () {
         esac
     done
     shift "$(( OPTIND - 1 ))"
-    echo $1
-    #Throw exception if both arguments are called
-    if [[ -n $BaseName ]] && [[ -n $OmitSignal ]]; then
-       echo "only pick -b or -o arguments"
-       exit
-    fi
 
     echo -e "${FileName}TotalSeq\tLength\tGC\tAvgQScore (min,max)";
     for file in $@
@@ -46,7 +40,12 @@ extract_fastqc () {
          }}' OFS='\t'
     done
 }
-
+#print header then continue with whatever command
+body() {
+    IFS= read -r header
+    printf '%s\n' "$header"
+    "$@"
+}
 calculate_percent () {
     #hard code col number $2-raw $8-pair $14-unpair $19-droppped (add)
     paste $@ | \

--- a/awk.sh
+++ b/awk.sh
@@ -25,7 +25,7 @@ extract_fastqc () {
         trimfile=${file##*/}
         unzip -p $file ${trimfile%.*}/fastqc_data.txt | \
         awk -F '\t'  -v omit=$OmitSignal -v base=$BaseNameSignal -v name=${trimfile%.*} \
-        '/Filename/{if ( length(base)==0 ) {file=$2} else {gsub(/_[12].*/,"");file=$2}}
+        '/Filename/{if ( length(base)==0 ) {file=$2} else {gsub(/_[12]P*\..*/,"");file=$2}}
         /Total Sequences/{seq=$2}
         /Sequence length/{len=$2}
         /%GC/{gc=$2}

--- a/awk.sh
+++ b/awk.sh
@@ -1,17 +1,51 @@
 extract_fastqc () {
-    echo -e "FileName\tTotalSeq\tPoorQualflag\tLength\tGC\tAvgQScore (min,max)";
+    if [ -z $1  ];
+    then
+        echo "Supplies one or more fastqc result in zip file."
+    fi
+    unset FileName BaseNameSignal OmitSignal OPTIND
+    FileName="FileName\t"
+    while getopts "bo" opt;
+    do
+        case $opt in
+            #Print filename as in basename
+            b) BaseNameSignal='1';;
+
+            #Omit filename column
+            o) OmitSignal='1'
+               FileName=""
+               ;;
+        esac
+    done
+    shift "$(( OPTIND - 1 ))"
+    echo $1
+    #Throw exception if both arguments are called
+    if [[ -n $BaseName ]] && [[ -n $OmitSignal ]]; then
+       echo "only pick -b or -o arguments"
+       exit
+    fi
+
+    echo -e "${FileName}TotalSeq\tLength\tGC\tAvgQScore (min,max)";
     for file in $@
     do
-        unzip -p $file ${file%.*}/fastqc_data.txt | \
-        awk -F '\t' '/Filename/{file=$2}
+        trimfile=${file##*/}
+        unzip -p $file ${trimfile%.*}/fastqc_data.txt | \
+        awk -F '\t'  -v omit=$OmitSignal -v base=$BaseNameSignal -v name=${trimfile%.*} \
+        '/Filename/{if ( length(base)==0 ) {file=$2} else {gsub(/_[12].*/,"");file=$2}}
         /Total Sequences/{seq=$2}
-        /Sequences flagged as poor quality/{flg=$2}
         /Sequence length/{len=$2}
         /%GC/{gc=$2}
         /Per sequence quality scores/,/END/{nr[NR]=$1; n++ ;nrr[n]=$1 ; min=nrr[3]; max=nr[NR-1] ;$3=$1*$2; sumn+=$2;sum+=$3 ;}
-        END{printf "%s\t%s\t%s\t%s\t%.3f\t%.3f (%s,%s)\n",file,seq,flg,len,gc,sum/sumn,min,max}';
+    END{if (length(omit)==0){
+        if ( sumn==0 ) {printf "%s\t%s\t%s\t%.3f\t%.3f (%s,%s)\n",file,0,0,0,0,0,0 ; exit};
+        printf "%s\t%s\t%s\t%.3f\t%.3f (%s,%s)\n",file,seq,len,gc,sum/sumn,min,max
+         }
+    else {
+        if ( sumn==0 ) {printf "%s\t%s\t%.3f\t%.3f (%s,%s)\n",0,0,0,0,0,0 ; exit};
+        printf "%s\t%s\t%.3f\t%.3f (%s,%s)\n",seq,len,gc,sum/sumn,min,max
+         }}' OFS='\t'
     done
-    }
+}
 
 calculate_percent () {
     #hard code col number $2-raw $8-pair $14-unpair $19-droppped (add)

--- a/modules.nf
+++ b/modules.nf
@@ -32,12 +32,13 @@ process FASTQC_BEFORE_TRIM {
 process EXTRACT_FASTQC_BEFORE_TRIM {
   publishDir "$params.results/qc_table", mode: 'copy'
   input: 
-    path fwd
-    path rvs
-
+    path fastqc_zip
   output:
     path "*_raw.txt" 
 
+  script:
+  def fwd = fastqc_zip.findAll { it =~ /.*_1_fastqc.zip/ }.join(' ')
+  def rvs = fastqc_zip.findAll { it =~ /.*_2_fastqc.zip/ }.join(' ')
   """
   #!/bin/bash
   source ${baseDir}/awk.sh 
@@ -159,13 +160,15 @@ process CREATE_TRIM_SUMMARY_TABLE {
 process MERGE_UNPAIRED_READ {
  
   input: 
-    tuple val(id),path(unpaired_read)
+    tuple val(id),path (unpaired_read)
   output:
-    tuple val(id), path("*_U.fastq.gz")
+    tuple val(id),path("*_U.fastq.gz")
 
-  """
-  cat $unpaired_read > ${id}_U.fastq.gz
-  """
+  script: 
+    def unpair = unpaired_read.findAll{ it =~ /.*U.fastq.gz/}.join(' ')
+      """
+      cat $unpair > ${id}_U.fastq.gz
+      """
 }
 
 /*
@@ -178,15 +181,14 @@ process FASTQC_AFTER_TRIM {
   tag "$id"
 
   input:
-    tuple val(id), path(reads_pair)
-    tuple val(id), path(reads_unpair)
-    
+    tuple val(id), path(pair)
+    tuple val(id_u), path(unpair)
   output:
     path "*.zip"
     
 
   """
-  ${baseDir}/prog/FastQC/fastqc $reads_pair $reads_unpair --noextract --quiet
+  ${baseDir}/prog/FastQC/fastqc $pair $unpair  --noextract --quiet
   """
 }
 
@@ -200,22 +202,33 @@ process FASTQC_AFTER_TRIM {
 process EXTRACT_FASTQC_AFTER_TRIM {
   publishDir "$params.results/qc_table", mode: 'copy'
   input: 
-    path fwd_P
-    path rvs_P
-    path fwd_U
-    path rvs_U
-
+    path fastqc_zip
   output:
     path "*cleaned.txt" 
   
-  """
-  #!/bin/bash
-  source ${baseDir}/awk.sh 
-  paste <(extract_fastqc -b ${fwd_P}) <(extract_fastqc -o ${rvs_P}) <(extract_fastqc -o ${fwd_U}) <(extract_fastqc -o ${rvs_U}) | body sort -k1 > qc_cleaned.txt
-    
-  """ 
+  script:
+    def fwd_pair = fastqc_zip.findAll { it =~ /.*1P_fastqc.zip$/ }.join(' ')
+    def rvs_pair = fastqc_zip.findAll { it =~ /.*2P_fastqc.zip$/ }.join(' ')
+    if (params.mergeUnpair){
+    def unpair = fastqc_zip.findAll {it =~ /.*U_fastqc.zip$/ }.join(' ')
+      """
+      #!/bin/bash
+      source ${baseDir}/awk.sh 
+      paste <(extract_fastqc -b ${fwd_pair}) <(extract_fastqc -o ${rvs_pair}) <(extract_fastqc -o ${unpair}) | body sort -k1 > qc_cleaned.txt
+        
+      """
+    } else {
+    def fwd_unpair = fastqc_zip.findAll { it =~ /.*1U_fastqc.zip$/ }.join(' ')
+    def rvs_unpair = fastqc_zip.findAll { it =~ /.*2U_fastqc.zip$/ }.join(' ')
+      """
+      #!/bin/bash
+      source ${baseDir}/awk.sh 
+      paste <(extract_fastqc -b ${fwd_pair}) <(extract_fastqc -o ${rvs_pair}) <(extract_fastqc -o ${fwd_unpair}) <(extract_fastqc -o ${rvs_unpair}) | body sort -k1 > qc_cleaned.txt
+        
+      """ 
+  
+    }
 }
-
 /*
  * Step 3c: Merge QC data of paired and unpaired samples into two different table
  * Input: [samplename]_{1,2}P_Trimmed.txt , [samplename]_{1,2}U_Trimmed.txt
@@ -228,30 +241,27 @@ process FINALISE_QCTABLE {
   path qc_raw
   path qc_trim
   path trim_sum
-  val mergeUnpair
 
   output:
   path "*qc_table.txt" 
   script:
-  if (mergeUnpair){
+  if (params.mergeUnpair){
   """
-
-  cat ${qc_trim} | sort | grep P.fastq.gz > qc_pair
-  awk -F '\\t' 'NR>1{for(i=0;i<2;i++)print}' ${trim_sum} | \
-  awk -F '\\t' 'NR==FNR{sur[NR]=\$1;next} {\$2 = \$2 " (" sur[FNR] ")"; print}' OFS='\\t' - qc_pair > qc_pair_nh
-
-  cat ${qc_trim} | sort |grep U.fastq.gz > qc_unpair
-  awk -F '\\t' 'NR>1{\$5=\$2+\$3; print}' OFS='\\t' ${trim_sum}| \
-  awk -F '\\t' 'NR==FNR{sur[NR]=\$5;dro[NR]=\$4;next} {\$2 = \$2 " (" sur[FNR] ")";print \$0, dro[FNR]}' OFS='\\t' - qc_unpair |sed G > qc_unpair_nh
-
-  cat <(echo "${params.qc_header}") qc_pair_nh > qc_pair.txt
-  cat <(echo -e "${params.qc_header}\tDropped") qc_unpair_nh  > qc_unpair.txt
+  #!/bin/bash 
+  join --header -t \$'\\t' qc_raw.txt qc_cleaned.txt | \
+  awk -F '\t' 'NR==1{
+      \$(NF+1)="Drop";
+      } 
+  NR>1{
+      \$10= \$10 " (" \$10/\$2*100 ")";
+      \$14= \$14 " (" \$14/\$2*100 ")"; 
+      \$18= \$18 " (" \$18/\$2*100 ")"; 
+      \$(NF+1)=\$2+\$6-\$10-\$14-\$18-\$22 " (" (\$2+\$6-\$10-\$14-\$18)/(\$2+\$6)*100 ")";
+      } 
+      {print}' OFS='\\t' > qc_table.txt
   
-  timestamp=\$(date '+%H%M%d%m%y')
-  paste ${qc_raw} qc_pair.txt qc_unpair.txt | \
-  awk -F '\\t' 'NR>1&&\$NF{\$NF= \$2-\$8-\$14 " (" \$NF ")"}{print}' OFS='\\t' > \${timestamp}_qc_table.txt 
   """
-
+ 
   } else {
   
   """
@@ -265,10 +275,12 @@ process FINALISE_QCTABLE {
       \$14= \$14 " (" \$14/\$2*100 ")"; 
       \$18= \$18 " (" \$18/\$2*100 ")"; 
       \$22= \$22 " (" \$22/\$2*100 ")"; 
-      \$NF=\$2+\$6-\$10-\$14-\$18-\$22 " (" (\$2+\$6-\$10-\$14-\$18-\$22)/(\$2+\$6)*100 ")";
+      \$(NF+1)=\$2+\$6-\$10-\$14-\$18-\$22 " (" (\$2+\$6-\$10-\$14-\$18-\$22)/(\$2+\$6)*100 ")";
       } 
-      {print}' OFS='\\t' > qc_table.txt
-  
+      {print}' OFS='\\t' > qc_table_tmp.txt
+  echo -e "RAW\t\t\t\t\t\t\t\t\tTRIMMED" > header
+  echo -e "FWD\t\t\t\t\tRVS\t\t\t\tPAIR_FWD\t\t\t\tPAIR_RVS\t\t\t\tUNPAIR_FWD\t\t\t\tUNPAIR_RVS" >> header
+  cat header qc_table_tmp.txt > qc_table.txt
   """
   }
 }
@@ -281,7 +293,7 @@ process FINALISE_QCTABLE {
 
 process MULTIQC_FASTQC_AFTER_TRIM {
   publishDir "$params.results/multiqc", mode: 'copy'
-  errorStrategy 'ignore'
+  // errorStrategy 'ignore'
 
   input:
     path fastqc_after_all

--- a/sumqc
+++ b/sumqc
@@ -121,7 +121,12 @@ fi;
 
 if [ -n "$INPUTS" ]
 then
-    input="--input=$INPUTS/$filename"
+    if [ -d "$INPUTS" ]
+    then
+        input="--input=$INPUTS/$filename"
+    else
+        input="--input=$INPUTS"
+    fi
 else
     input="--input=$PWD/$filename"
 fi

--- a/sumqc
+++ b/sumqc
@@ -7,14 +7,14 @@ if [[ ! -d "$DIR"  ]]; then DIR="$PWD"; fi
 source "$DIR/awk.sh"
 
 usage() { 
-    echo "Usage: $0 [<SR|LR|QCsum>] [-p <pb-rs2|pb-sequel|ont-ligation|ont-rapid|ont-1dsq>] [-i <fq.gz>] [-o <outputDir>] [-m] [-q <qcoption>]" 1>&2 ;  
+    echo "Usage: $0 [<SR|LR|QCsum>] [-t <SE|PE>] [-p <pb-rs2|pb-sequel|ont-ligation|ont-rapid|ont-1dsq>] [-i <fq.gz>] [-o <outputDir>] [-m] [-q <qcoption>]" 1>&2 ;  
 }
 
 help() {
     printf "
-    sumQC contain the pipeline for QC, cleaning and, produce the summary of QC into one table including the tool to create data from the QC results manually. The workflows are managed by nextflow (visit https://www.nextflow.io/ for more info) which require java version of 8 or later. Software use in long read pipeline are written in python and need to download required packaged before use. (visit LongQC and Filtlong github page for more info)
+    sumQC contains the pipeline for QC, cleaning and, produce the summary of QC into one table including the tool to create data from the QC results manually. The workflows are managed by nextflow (visit https://www.nextflow.io/ for more info) which require java version of 8 or later. Software use in long read pipeline are written in python and need to download required packaged before use. (visit LongQC and Filtlong github page for more info)
 
-    Usage: $0 [<SR|LR|QCsum>] [-p <pb-rs2|pb-sequel|ont-ligation|ont-rapid|ont-1dsq>] [-i <fq.gz>] [-o <outputDir>] [-m] [-q <qcoption>] [-r]
+    Usage: $0 [<SR|LR|QCsum>] [-t <SE|PE>] [-p <pb-rs2|pb-sequel|ont-ligation|ont-rapid|ont-1dsq>] [-i <fq.gz>] [-o <outputDir>] [-m] [-q <qcoption>] [-r]
 
 DESCRIPTION
 
@@ -57,9 +57,10 @@ READS=$1;
 shift;
 #path to call main.nf script outside its directory
 path=$(dirname $0)
-while getopts "p:i:o:mrq:h" o;
+while getopts "t:p:i:o:mrq:h" o;
 do
     case $o in
+        t) READTYPES=$OPTARG ;;
         p) PLATFORM=$OPTARG ;;
         i) INPUTS=$OPTARG ;;
         o) OUTPUTS=$OPTARG ;;
@@ -78,6 +79,18 @@ then
         SR) main_script=main.nf 
             filename="*{1,2}.fq.gz"
             run=true
+            if [ -n "$READTYPES" ]
+            then
+                case $READTYPES in 
+                    SE) singleend="--SE=true";;
+                    PE) singleend="--SE=false";;
+                    *) echo "must specify PE for paired-end or SE for single-end"
+                       exit 65 ;;
+                esac
+            else
+                echo "use -t to specify read type"
+                exit 65
+            fi
             ;;
         LR) main_script=main-longread.nf 
             filename="*.fq.gz"
@@ -117,7 +130,7 @@ fi
 
 if [ -n "$OUTPUTS" ]
 then 
-    output="--results=$OUTPUT"
+    output="--results=$OUTPUTS"
 else
     output="--results=$PWD/results"
 fi
@@ -148,6 +161,6 @@ fi
 
 if [ $run ]
 then
-    echo "nextflow run $path/$main_script $platform $input $output $merge --qc_option=$qcopt" $RESUME
-    nextflow run $path/$main_script $platform $input $output $merge --qc_option="$qcopt" $RESUME
+    echo "nextflow run $path/$main_script $platform $input $output $merge --qc_option=$qcopt" $RESUME $singleend
+    nextflow run $path/$main_script $platform $input $output $merge --qc_option="$qcopt" $RESUME $singleend
 fi


### PR DESCRIPTION
Support single-end using -t to specify either single-end (SE) or paired-end (PE).
Usage:
./sumqc [<SR|LR>] [-t <SE|PE>] [-p <pb-rs2|pb-sequel|ont-ligation|ont-rapid|ont-1dsq>] [-i <fq.gz>] [-o <outputDir>] [-m] [-q <qcoption>] [-r]


The table extract from fastQC now look like this.

SE table:
FileName|TotalSeq|Length|GC|AvgQScore (min,max)|TotalSeq|Length|GC|AvgQScore (min,max)|TotalSeq|Length|GC|AvgQScore (min,max)|TotalSeq|Length|GC|AvgQScore (min,max)|TotalSeq|Length|GC|AvgQScore (min,max)|TotalSeq|Length|GC|AvgQScore (min,max)|Drop
------------ | -------------|------------ | -------------|------------ | -------------|------------ | -------------|------------ | -------------|------------ | -------------|------------ | -------------|------------ | -------------|------------ | -------------|-------------|-------------|-------------|-------------|-------------|-------------|-------------|-----------
test_1-1T|10000|150|65.000|33.828 (27,37)|NA|NA|NA|NA|3460 (34.6)|70-150|61.000|35.429 (33,37)|NA|NA|NA|NA|NA|NA|NA|NA|NA|NA|NA|NA|6540 (65.4)
test_3-1T|10000|150|66.000|31.542 (26,37)|NA|NA|NA|NA|6432 (64.32)|70-150|64.000|35.715 (34,37)|NA|NA|NA|NA|NA|NA|NA|NA|NA|NA|NA|NA|3568 (35.68)

PE table:
FileName|TotalSeq|Length|GC|AvgQScore (min,max)|TotalSeq|Length|GC|AvgQScore (min,max)|TotalSeq|Length|GC|AvgQScore (min,max)|TotalSeq|Length|GC|AvgQScore (min,max)|TotalSeq|Length|GC|AvgQScore (min,max)|TotalSeq|Length|GC|AvgQScore (min,max)|Drop
------------ | -------------|------------ | -------------|------------ | -------------|------------ | -------------|------------ | -------------|------------ | -------------|------------ | -------------|------------ | -------------|------------ | -------------|-------------|-------------|-------------|-------------|-------------|-------------|-------------|-----------
test_1-1T|10000|150|65.000|33.828 (27,37)|10000|150|66.000|31.439 (26,37)|2636 (26.36)|70-150|62.000|35.872 (34,37)|2636 (26.36)|70-150|61.000|35.483 (33,37)|3796 (37.96)|70-150|65.000|35.606 (34,37)|819 (8.19)|70-150|61.000|35.258 (33,37)|10113 (50.565)
test_3-1T|10000|150|66.000|33.917 (27,37)|10000|150|66.000|31.542 (26,37)|2900 (29)|70-150|63.000|35.941 (34,37)|2900 (29)|70-150|62.000|35.490 (33,37)|3748 (37.48)|70-150|66.000|35.676 (34,37)|784 (7.84)|70-150|62.000|35.310 (33,37)|9668 (48.34)
